### PR TITLE
fix: cache the `io` builtin package

### DIFF
--- a/src/busted/outputHandlers/htest.lua
+++ b/src/busted/outputHandlers/htest.lua
@@ -1,5 +1,6 @@
 local pretty = require 'pl.pretty'
 local term = require 'term'
+local io = io
 
 local colors
 


### PR DESCRIPTION
resolves #2 